### PR TITLE
projects: Add support for customized project names

### DIFF
--- a/jobserv/api/build.py
+++ b/jobserv/api/build.py
@@ -12,7 +12,7 @@ from jobserv.models import Build, BuildStatus, Project, db
 from jobserv.trigger import trigger_build
 
 blueprint = Blueprint(
-    'api_build', __name__, url_prefix='/projects/<proj>')
+    'api_build', __name__, url_prefix='/projects/<project:proj>')
 
 
 @blueprint.route('/builds/', methods=('GET',))

--- a/jobserv/api/github.py
+++ b/jobserv/api/github.py
@@ -144,7 +144,7 @@ def _filter_events(event):
         raise ApiError(200, 'OK, ignoring')
 
 
-@blueprint.route('/<proj>/', methods=('POST',))
+@blueprint.route('/<project:proj>/', methods=('POST',))
 def on_webhook(proj):
     trigger = get_or_404(ProjectTrigger.query.filter(
         ProjectTrigger.type == TriggerTypes.github_pr.value

--- a/jobserv/api/gitlab.py
+++ b/jobserv/api/gitlab.py
@@ -154,7 +154,7 @@ def _filter_events(event):
         raise ApiError(400, 'Invalid action: ' + event)
 
 
-@blueprint.route('/<proj>/', methods=('POST',))
+@blueprint.route('/<project:proj>/', methods=('POST',))
 def on_webhook(proj):
     trigger = get_or_404(ProjectTrigger.query.filter(
         ProjectTrigger.type == TriggerTypes.gitlab_mr.value

--- a/jobserv/api/project.py
+++ b/jobserv/api/project.py
@@ -14,7 +14,7 @@ def project_list():
     return paginate('projects', Project.query)
 
 
-@blueprint.route('/<proj>/', methods=('GET',))
+@blueprint.route('/<project:proj>/', methods=('GET',))
 def project_get(proj):
     p = get_or_404(Project.query.filter_by(name=proj))
     return jsendify({'project': p.as_json(detailed=True)})

--- a/jobserv/api/run.py
+++ b/jobserv/api/run.py
@@ -17,8 +17,8 @@ from jobserv.project import ProjectDefinition
 from jobserv.sendmail import notify_build_complete
 from jobserv.trigger import trigger_runs
 
-blueprint = Blueprint('api_run', __name__,
-                      url_prefix='/projects/<proj>/builds/<int:build_id>/runs')
+prefix = '/projects/<project:proj>/builds/<int:build_id>/runs'
+blueprint = Blueprint('api_run', __name__, url_prefix=prefix)
 
 
 @blueprint.route('/', methods=('GET',))

--- a/jobserv/api/test.py
+++ b/jobserv/api/test.py
@@ -8,9 +8,8 @@ from jobserv.jsend import jsendify
 from jobserv.models import BuildStatus, Run, Test, TestResult, db
 from jobserv.storage import Storage
 
-blueprint = Blueprint(
-    'api_test', __name__,
-    url_prefix='/projects/<proj>/builds/<int:build_id>/runs/<run>/tests')
+prefix = '/projects/<project:proj>/builds/<int:build_id>/runs/<run>/tests'
+blueprint = Blueprint('api_test', __name__, url_prefix=prefix)
 
 
 @blueprint.route('/', methods=('GET',))

--- a/jobserv/settings.py
+++ b/jobserv/settings.py
@@ -32,6 +32,11 @@ RUN_URL_FMT = os.environ.get('RUN_URL_FMT')
 # BUILD_URL_FMT = 'https://example.com/{project}/{build}
 # RUN_URL_FMT = 'https://example.com/{project}/{build}/{run}
 
+# Allows a custom rule for project names.
+# Eg - projects could be defined as user/projname with:
+#   PROJECT_NAME_REGEX = '(?:\S+\/\S+^/)'
+PROJECT_NAME_REGEX = os.environ.get('PROJECT_NAME_REGEX')
+
 SMTP_SERVER = os.environ.get('SMTP_SERVER', 'smtp.gmail.com')
 SMTP_USER = os.environ.get('SMTP_USER')
 SMTP_PASSWORD = os.environ.get('SMTP_PASSWORD')

--- a/jobserv/storage/local_storage.py
+++ b/jobserv/storage/local_storage.py
@@ -85,8 +85,9 @@ def _get_run(proj, build_id, run):
     ).first_or_404()
 
 
-@blueprint.route('/<sig>/<proj>/builds/<int:build_id>/runs/<run>/<path:path>',
-                 methods=('PUT',))
+@blueprint.route(
+    '/<sig>/<project:proj>/builds/<int:build_id>/runs/<run>/<path:path>',
+    methods=('PUT',))
 def run_upload_artifact(sig, proj, build_id, run, path):
     run = _get_run(proj, build_id, run)
 


### PR DESCRIPTION
NOTE: This change is a no-op unless default settings are updated.

This allows users to customize/validate the format of project names.
For instance if a deployment wanted to employ something like:

 /projects/~user/project1/
 /projects/teamX/project1/

The old system would fail. However, with this change a regex like:

 (?:\S+\/\S+^/)

could be used to support such a feature.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>