### PR TITLE
Fix changes around triggered test runs

### DIFF
--- a/jobserv/api/run.py
+++ b/jobserv/api/run.py
@@ -99,9 +99,9 @@ def _handle_triggers(storage, run):
                 if run.status == BuildStatus.PASSED:
                     _create_triggers(projdef, storage, run.build, params,
                                      secrets, rt.get('triggers', []))
-                if run.build.complete:
-                    _handle_build_complete(projdef, storage, run.build, params,
-                                           secrets, run_trigger)
+        if run.build.complete:
+            _handle_build_complete(projdef, storage, run.build, params,
+                                   secrets, run_trigger)
     except ValueError as e:
         current_app.logger.exception(
             'Caught integrity error and failed run: %d', run.id)

--- a/jobserv/api/run.py
+++ b/jobserv/api/run.py
@@ -195,7 +195,7 @@ def run_update(proj, build_id, run):
                 if _failed_tests(storage, r):
                     status = BuildStatus.FAILED
                 storage.copy_log(r)
-            with r.build.locked(r):
+            with r.build.locked():
                 r.set_status(status)
                 if r.complete:
                     _handle_triggers(storage, r)


### PR DESCRIPTION
We have a project with the following snippet:

      - name: fota-compile-{loop}
        container: linarotechnologies/genesis-sdk
        host-tag: amd64
        script-repo:
          name: ltd
          path: tools/fota-rebase-compile.sh
        loop-on:
          - param: PLATFORM
            values: [frdm_k64f, 96b_nitrogen]
        triggers:
          - name: lava-test
            run-names: "{name}-{loop}"
    email:
      users: 'ci-notifications@opensourcefoundries.com'

  - name: lava-test
    type: lava
    runs:
      - name: lava
        container: linarotechnologies/genesis-sdk
        host-tag: amd64
        script-repo:
          name: ltd
          path: tools/fota-test.sh

We are hitting two issues with the current code:
1) We the code for handling notifications never sees the build as complete.
2) We fail to trigger build.complete because we were trying to match the triggered lava-run of "lava-96b_nitrogen" with the run name "lava".

This fixes both (i hope).