### PR TITLE
schema: Add a project-wide email setting

### DIFF
--- a/jobserv/api/run.py
+++ b/jobserv/api/run.py
@@ -60,7 +60,7 @@ def _create_triggers(projdef, storage, build, params, secrets, triggers):
 
 
 def _handle_build_complete(projdef, storage, build, params, secrets, trigger):
-    email = trigger.get('email')
+    email = trigger.get('email', projdef.project_email)
     if email:
         if build.status == BuildStatus.FAILED \
                 or not email.get('only_failures'):

--- a/jobserv/project-schema.yml
+++ b/jobserv/project-schema.yml
@@ -34,6 +34,17 @@ mapping:
   timeout:
     type: int
     required: True
+  email:
+    required: False
+    type: map
+    mapping:
+      users:
+        type: str
+        required: True
+      only_failures:
+        type: bool
+        required: False
+
   triggers:
     type: seq
     sequence:

--- a/jobserv/project.py
+++ b/jobserv/project.py
@@ -41,6 +41,10 @@ class ProjectDefinition(object):
     def params(self):
         return self._data.get('params', {})
 
+    @property
+    def project_email(self):
+        return self._data.get('email', None)
+
     def _expand_run_loops(self):
         for trigger in self.triggers:
             for run in trigger['runs']:


### PR DESCRIPTION
The current email schema makes it hard to set an email for triggers
that trigger other runs. eg:

triggers:
  - name: slimmed down example
    runs:
      - name: compile-{loop}
        loop-on:
          - param: PLATFORM
            values: [frdm_k64f, 96b_nitrogen]
        triggers:
          - name: lava-test
            run-names: "{name}-{loop}"
    email:
      users: 'foo@example.com'

  - name: lava-test
    type: lava
    runs:
      - name: lava

The intent of this author is probably to notify at the end of the
lava triggered runs. However, the author would have to add an email
clause to the lava-test and then update the current email clause to
only notify on failures to get the effect of what a project-wide email
setting would do.

I considered removing the other email stanzas (per run and trigger),
but they *could* be handy and have unit-test code, so I've left them.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>