### PR TITLE
Make authenticated requests inside a run

### DIFF
--- a/runner/jobserv_runner/handlers/generate-public-url.py
+++ b/runner/jobserv_runner/handlers/generate-public-url.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2017 Linaro Limited
 # Author: Andy Doan <andy.doan@linaro.org>
 
+import base64
 import sys
 import urllib.request
 
@@ -16,11 +17,33 @@ class NoRedirection(urllib.request.HTTPErrorProcessor):
     https_response = http_response
 
 
+# Find the auth token. Python's netrc implementation has a bug forcing files
+# to have a password entry. Our github entries only use "login". This is a
+# minimal parser that depends on simple.py to produce a sane entry
+token = None
+with open('/root/.netrc') as f:
+    matched = False
+    for line in f:
+        key, val = line.strip().split(' ', 2)
+        if key == 'machine' and val in url:
+            matched = True
+        if matched and key == 'password':
+            token = val
+            break
+
+if not token:
+    sys.exit('.netrc missing entry for ' + url)
+
 # return the 302 redirect value for the url
 opener = urllib.request.build_opener(NoRedirection)
-# make the link valid for 2 hours
-req = urllib.request.Request(url, headers={'X-EXPIRATION': '7200'})
+token = base64.encodebytes(token.encode()).decode().strip()
+headers = {
+    'X-EXPIRATION': '7200',  # make the link valid for 2 hours
+    'Authorization': 'Basic ' + token
+}
+req = urllib.request.Request(url, headers=headers)
 resp = opener.open(req)
 if resp.status != 302:
-    raise RuntimeError('Expected a 302 redirect from URL: ' + url)
+    raise RuntimeError('Expected a 302 redirect from URL(%s):\n%s' % (
+                       resp.status, resp.read().decode()))
 print(resp.headers['location'])

--- a/tests/runner/test_handler_git.py
+++ b/tests/runner/test_handler_git.py
@@ -47,6 +47,7 @@ class GitPollerHandlerTest(TestCase):
         self.handler.rundef = {
             'script': '',
             'persistent-volumes': None,
+            'run_url': 'foo',
             'env': {
                 'GIT_URL': repo_src,
                 'GIT_SHA': repo_sha,
@@ -64,6 +65,7 @@ class GitPollerHandlerTest(TestCase):
         self.handler.rundef = {
             'script': '',
             'persistent-volumes': None,
+            'run_url': 'foo',
             'env': {
                 'GIT_URL': '/tmp/foo-bar-does-not-existz',
                 'GIT_SHA': 'doesnt matter',
@@ -79,6 +81,7 @@ class GitPollerHandlerTest(TestCase):
         self.handler.rundef = {
             'script': '',
             'persistent-volumes': None,
+            'run_url': 'foo',
             'env': {
                 'GIT_URL': repo_src,
                 'GIT_SHA': 'badbeef',

--- a/tests/runner/test_handler_lava.py
+++ b/tests/runner/test_handler_lava.py
@@ -34,6 +34,7 @@ class LavaHandlerTest(TestCase):
         self.handler.rundef = {
             'script': '',
             'persistent-volumes': None,
+            'run_url': 'foo',
             'secrets': {
                 'LAVA_USER': 'luser',
                 'LAVA_TOKEN': 'ltoken',

--- a/tests/runner/test_handler_lava_pr.py
+++ b/tests/runner/test_handler_lava_pr.py
@@ -44,6 +44,7 @@ class LavaPRHandlerTest(TestCase):
         self.handler.rundef = {
             'script': '',
             'persistent-volumes': None,
+            'run_url': 'z',
             'secrets': {
                 'LAVA_USER': 'luser',
                 'LAVA_TOKEN': 'ltoken',

--- a/tests/runner/test_handler_simple.py
+++ b/tests/runner/test_handler_simple.py
@@ -16,6 +16,7 @@ class TestHandler(SimpleHandler):
     _jobserv = mock.Mock()
 
     def __init__(self, worker_dir, run_dir, jobserv, rundef):
+        jobserv._api_key = 'mocked not secure'
         super().__init__(worker_dir, run_dir, jobserv, rundef)
         self.action()
 
@@ -123,7 +124,7 @@ class SimpleHandlerTest(TestCase):
         with self.handler.docker_login():
             with open(path) as f:
                 data = json.load(f)
-                self.assertEquals('1234', data['auths']['server.com']['auth'])
+                self.assertEqual('1234', data['auths']['server.com']['auth'])
         with open(path) as f:
             self.assertEqual(contents, json.load(f))
 
@@ -133,6 +134,7 @@ class SimpleHandlerTest(TestCase):
             'secrets': None,
             'persistent-volumes': None,
             'script': 'foo',
+            'run_url': 'http://for-simulator-instructions/run',
         }
         self.handler.prepare_mounts()
 
@@ -143,6 +145,7 @@ class SimpleHandlerTest(TestCase):
             'secrets': {'foo': 'foo-secret-value'},
             'persistent-volumes': {'blah': '/foo'},
             'script': 'foo',
+            'run_url': 'http://for-simulator-instructions/run',
         }
         self.handler.prepare_mounts()
 
@@ -175,6 +178,7 @@ class SimpleHandlerTest(TestCase):
             'project': 'p',
             'secrets': {'foo': 'foo-secret-value'},
             'persistent-volumes': {'blah': '/foo'},
+            'run_url': 'http://for-simulator-instructions/run',
             'script-repo': {
                 # just clone ourself
                 'clone-url': repo,
@@ -191,6 +195,7 @@ class SimpleHandlerTest(TestCase):
             'project': 'p',
             'container': 'busybox',
             'persistent-volumes': {'blah': '/foo'},
+            'run_url': 'http://for-simulator-instructions/run',
             'script': '''#!/bin/sh -e\n
                       echo "running"
                       echo "persistent" > /foo/p.txt


### PR DESCRIPTION
Scripts inside of Runs need to be able to make authenticated requests to the JobServ in the event a API has been locked down with a custom permissions implementation. eg A lava-run needs to find all the artifacts from the RUN it was triggered by. This sets up a .netrc file inside the container that should help things work transparently.