### PR TITLE
downloads: Produce more sane download names

### DIFF
--- a/jobserv/storage/gce_storage.py
+++ b/jobserv/storage/gce_storage.py
@@ -52,4 +52,6 @@ class Storage(BaseStorage):
         expiration = int(request.headers.get('X-EXPIRATION', '90'))
         b = self.bucket.blob(self._get_run_path(run, path))
         expiration = datetime.timedelta(seconds=expiration)
-        return redirect(b.generate_signed_url(expiration=expiration))
+        rd = 'inline; filename=%s' % os.path.basename(path)
+        return redirect(b.generate_signed_url(
+            expiration=expiration, response_disposition=rd))


### PR DESCRIPTION
Clicking URLs inside a browser for Run artifacts results in downloads
with strange names.

For example, something like:
 ... artifacts/build-hikey/bootloader/l-loader.bin

 downloads as "%2F26%2Fbuild-hikey%2Fbootloader%2Fl-loader.bin".

By doing an inline content-disposition, normal textual files that can
be displayed in the browser will continue to render properly, and
binary downloads will be presented with sane names like l-loader.bin.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>