### PR TITLE
runs: Add back "RUNNING" status event

### DIFF
--- a/jobserv/models.py
+++ b/jobserv/models.py
@@ -415,7 +415,10 @@ class Run(db.Model, StatusMixin):
             return Run.query.filter(Run.status == BuildStatus.RUNNING).first()
         if rows == 1:
             cursor.execute('select @run_id')
-            return Run.query.get(cursor.fetchone()[0])
+            r = Run.query.get(cursor.fetchone()[0])
+            db.session.add(RunEvents(r, BuildStatus.RUNNING))
+            db.session.commit()
+            return r
 
 
 class RunEvents(db.Model, StatusMixin):


### PR DESCRIPTION
When code was converted to use "pop_queued", we forgot to include the
logic to add a RUNNING status event. This is causing build times to
only be the amount of time it took *upload* the artifacts.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>