### PR TITLE
jobserv/app: split secrets using only the first seperator

### DIFF
--- a/jobserv/app.py
+++ b/jobserv/app.py
@@ -111,7 +111,7 @@ def add_trigger(project, user, type, secrets, definition_repo, definition_file,
             for _ in range(32))
     secret_map = {'webhook-key': key}
     for secret in (secrets or []):
-        k, v = secret.split('=')
+        k, v = secret.split('=', 1)
         secret_map[k.strip()] = v.strip()
 
     type = TriggerTypes[type].value


### PR DESCRIPTION
Tokens may use '=' so only evaluate the first seperator found when
parsing secrets.

Signed-off-by: Tyler Baker <tyler@opensourcefoundries.com>