### PR TITLE
runner: Add reboot support

### DIFF
--- a/runner/jobserv_runner/handlers/git_poller.py
+++ b/runner/jobserv_runner/handlers/git_poller.py
@@ -50,7 +50,10 @@ class GitPoller(SimpleHandler):
 
         repo_dir = os.path.join(self.run_dir, 'repo')
         with self.log_context('Cloning git repository') as log:
-            self._clone(log, repo_dir)
+            if os.path.exists(repo_dir):
+                log.warn('Reusing repository from previous run')
+            else:
+                self._clone(log, repo_dir)
         mounts.append((repo_dir, '/repo'))
         self.container_cwd = '/repo'
         return mounts


### PR DESCRIPTION
This adds a simple mechanism that allows a run to cause the server
to do a reboot and resume. If a run creates a file called
/archive/execute-on-reboot, the handler and jobserv-worker will set
things up reboot and resume the run.

Since this could easily be (ab)used, the jobserv-worker script does
not call "sudo reboot". ie - A non-privileged worker (not running as
root) won't be able to reboot and the run will fail.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>