### PR TITLE
settings.py: update LAVA base url

### DIFF
--- a/jobserv/settings.py
+++ b/jobserv/settings.py
@@ -53,7 +53,7 @@ SMTP_PASSWORD = os.environ.get('SMTP_PASSWORD')
 NOTIFICATION_EMAILS = os.environ.get('NOTIFICATION_EMAILS')
 
 LAVA_URLBASE = os.environ.get(
-    'LAVA_URLBASE', 'http://lava.linarotechnologies.org')
+    'LAVA_URLBASE', 'https://lava.foundries.io')
 
 # every 90 seconds
 GIT_POLLER_INTERVAL = int(os.environ.get('GIT_POLLER_INTERVAL', '90'))


### PR DESCRIPTION
The LAVA server has now moved to https://lava.foundries.io, so lets
update this reference.

Signed-off-by: Tyler Baker <tyler@opensourcefoundries.com>