### PR TITLE
worker: Fix missing stout

### DIFF
--- a/runner/jobserv_runner/cmd.py
+++ b/runner/jobserv_runner/cmd.py
@@ -50,10 +50,8 @@ def stream_cmd(stream_cb, cmd, cwd=None):
                     last_update = now
             else:
                 last_buff += buff
+    finally:
         if last_buff:
             if not stream_cb(last_buff):
                 # Unable to stream part of command output
                 raise subprocess.CalledProcessError(0, cmd)
-    except subprocess.CalledProcessError as e:
-        e.unstreamed = last_buff
-        raise e


### PR DESCRIPTION
The code was failing to stream the last bit of stdout when something
failed which basically meant we were losing the most important bit
of debugging information. This was related to the recent change to
the polling logic

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>