### PR TITLE
LAVA: Handle runs with no submissions

### DIFF
--- a/runner/jobserv_runner/handlers/lava-submit.py
+++ b/runner/jobserv_runner/handlers/lava-submit.py
@@ -70,3 +70,5 @@ with open(sys.argv[1]) as f:
     joburl = _getenv('LAVA_RPC').replace('RPC2', 'scheduler/job/%d' % jobid)
     print('Lava Job: %s' % joburl)
     _post(RUN_URL + 'tests/' + name + '/', data={'context': joburl})
+    with open('/tmp/lava-submitted', 'a') as f:
+        f.write(joburl + '\n')

--- a/runner/jobserv_runner/handlers/lava.py
+++ b/runner/jobserv_runner/handlers/lava.py
@@ -14,7 +14,7 @@ class NoStopApi(JobServApi):
        that the jobserv's lava logic will PASS/FAIL it when lava completes"""
 
     def update_status(self, status, msg, metadata=None):
-        if status == 'PASSED':
+        if status == 'PASSED' and os.path.exists('/tmp/lava-submitted'):
             # don't "complete" the run since we are waiting on lava
             status = 'RUNNING'
         super().update_status(status, msg, metadata)


### PR DESCRIPTION
On rare occasions a lava run might not submit anything to LAVA. In
this case the run will remain in RUNNING forever since the LAVA
reaper won't find anything.

This is a simple way for the handler to see we should let the run
complete.

Signed-off-by: Andy Doan <andy@foundries.io>